### PR TITLE
Sort order for static factory methods is now stable

### DIFF
--- a/src/com/googlecode/yadic/resolvers/StaticMethodResolver.java
+++ b/src/com/googlecode/yadic/resolvers/StaticMethodResolver.java
@@ -6,7 +6,6 @@ import com.googlecode.totallylazy.Option;
 import com.googlecode.totallylazy.Sequence;
 import com.googlecode.yadic.ContainerException;
 import com.googlecode.yadic.Resolver;
-import com.googlecode.yadic.generics.Types;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -14,16 +13,19 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.googlecode.totallylazy.Arrays.exists;
+import static com.googlecode.totallylazy.Callables.ascending;
 import static com.googlecode.totallylazy.Callables.cast;
 import static com.googlecode.totallylazy.Callables.descending;
 import static com.googlecode.totallylazy.Methods.genericParameterTypes;
 import static com.googlecode.totallylazy.Methods.genericReturnType;
+import static com.googlecode.totallylazy.Methods.methodName;
 import static com.googlecode.totallylazy.Methods.modifier;
 import static com.googlecode.totallylazy.Option.none;
 import static com.googlecode.totallylazy.Option.some;
 import static com.googlecode.totallylazy.Predicates.not;
 import static com.googlecode.totallylazy.Predicates.where;
 import static com.googlecode.totallylazy.Sequences.sequence;
+import static com.googlecode.totallylazy.comparators.Comparators.comparators;
 import static com.googlecode.yadic.generics.TypeConverter.convertParametersToInstances;
 import static com.googlecode.yadic.generics.Types.classOf;
 import static com.googlecode.yadic.generics.Types.matches;
@@ -50,7 +52,7 @@ public class StaticMethodResolver<T> implements Resolver<T> {
                 filter(modifier(PUBLIC).and(modifier(STATIC)).
                         and(where(genericReturnType(), matches(type)).
                                 and(where(genericParameterTypes(), not(exists(matches(type))))))).
-                sortBy(descending(arity()));
+                sortBy(comparators(descending(arity()), ascending(methodName())));
 
         if (methods.isEmpty()) {
             throw new ContainerException(concreteClass.getName() + " does not have any public static methods that return " + type);

--- a/test/com/googlecode/yadic/examples/MyStaticMethodClass.java
+++ b/test/com/googlecode/yadic/examples/MyStaticMethodClass.java
@@ -11,6 +11,10 @@ public class MyStaticMethodClass {
         return new MyStaticMethodClass("myStaticMethodClass1");
     }
 
+    public static MyStaticMethodClass myStaticMethodClass2a(String parameter1, Boolean parameter2) {
+        return new MyStaticMethodClass("myStaticMethodClass2a");
+    }
+
     public static MyStaticMethodClass myStaticMethodClass2(String parameter1, Integer parameter2) {
         return new MyStaticMethodClass("myStaticMethodClass2");
     }

--- a/test/com/googlecode/yadic/resolvers/StaticMethodResolverTest.java
+++ b/test/com/googlecode/yadic/resolvers/StaticMethodResolverTest.java
@@ -44,6 +44,17 @@ public class StaticMethodResolverTest {
         assertThat(staticMethodClass.constructedBy, is("myStaticMethodClass2"));
     }
 
+    @Test
+    public void sortOrderIsStableWhenMultipleMethodsExistWithTheSameArity() throws Exception {
+        StaticMethodResolver<MyStaticMethodClass> resolver = StaticMethodResolver
+            .staticMethodResolver(
+                containerWith("foobar").addInstance(Integer.class, 1).addInstance(Boolean.class, Boolean.TRUE),
+                MyStaticMethodClass.class);
+        MyStaticMethodClass staticMethodClass = resolver.resolve(MyStaticMethodClass.class);
+        assertThat(staticMethodClass, is(notNullValue()));
+        assertThat(staticMethodClass.constructedBy, is("myStaticMethodClass2"));
+    }
+
     @Test(expected = ContainerException.class)
     public void ignoresSelfReferencingStaticMethods() throws Exception {
         Container resolver = new SimpleContainer();


### PR DESCRIPTION
At present static factory methods on a parameter object are returned from the JVM in an unordered state. Yadic then sorts these by arity. However, two methods with the same arity will be returned in an undefined and (on the Oracle JDK at least) unstable order.

This patch changes the logic to sort first by arity and then by methodName, which sort ensure a stable sort regardless of JVM.
